### PR TITLE
chore(netlify): remove lighthouse plugin

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,4 @@
 publish = ".next"
 
 [[plugins]]
-  package = "@netlify/plugin-lighthouse"
-
-[[plugins]]
   package = "@netlify/plugin-nextjs"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Low to no plugin utilization, best to remove to speed up Netlify worker build time.
