### PR TITLE
fix(transactions): use vsize when calculating feeRate

### DIFF
--- a/src/pages/transactions/[txid].page.tsx
+++ b/src/pages/transactions/[txid].page.tsx
@@ -70,7 +70,9 @@ export default function TransactionPage(
   const dftx: DfTx<any> | undefined = getDfTx(props.vouts);
   const isDeFiTransaction = dftx !== undefined;
   const fee = getTransactionFee(props.transaction, props.vins, dftx);
-  const feeRate = fee.multipliedBy(100000000).dividedBy(props.transaction.size);
+  const feeRate = fee
+    .multipliedBy(100000000)
+    .dividedBy(props.transaction.vSize);
 
   return (
     <>

--- a/src/pages/transactions/_components/TransactionSummaryTable.tsx
+++ b/src/pages/transactions/_components/TransactionSummaryTable.tsx
@@ -128,6 +128,9 @@ function SummaryTableListRight(props: {
       <AdaptiveList.Row name="Size" testId="transaction-detail-size">
         {props.transaction.size} bytes
       </AdaptiveList.Row>
+      <AdaptiveList.Row name="vSize" testId="transaction-detail-vsize">
+        {props.transaction.vSize} bytes
+      </AdaptiveList.Row>
       <AdaptiveList.Row
         name="Received Time"
         testId="transaction-detail-received-time"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
- To display vSize in summary table
- To use vSize when calculating feeRate

#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Sample Links & Screenshots:

<!--
(Optional) Provide a link to changes made using Netlify Preview deployment.
-->

Link:

<details>
<summary>Desktop Screenshot</summary>

<!-- Image has to be between break lines -->

</details>
<details>
<summary>Mobile Screenshot</summary>

<!-- Image has to be between break lines -->

</details>

#### Additional comments?:

#### Developer Checklist:

<!--
Merging into the main branch implies your code is ready for production.
Before requesting for code review, please ensure that the following tasks
are completed. Otherwise, keep the PR drafted.
-->

- [x] Read your code changes at least once
- [ ] Tested on multiple web browsers
- [x] Tested responsiveness (e.g, iPhone, iPad, Desktop)
- [x] No console errors
- [ ] Unit tests\*
- [ ] Added e2e tests\*

<!--
* If applicable
-->
