### PR TITLE
fix(ocg): display pagination UI even when it is empty

### DIFF
--- a/src/pages/on-chain-governance/[proposalId]/index.page.tsx
+++ b/src/pages/on-chain-governance/[proposalId]/index.page.tsx
@@ -19,7 +19,10 @@ import classNames from "classnames";
 import BigNumber from "bignumber.js";
 import { EmptySection } from "@components/commons/sections/EmptySection";
 import { EnvironmentNetwork } from "@waveshq/walletkit-core";
-import { CursorPagination } from "@components/commons/CursorPagination";
+import {
+  CursorPage,
+  CursorPagination,
+} from "@components/commons/CursorPagination";
 import { getVoteCount } from "../shared/getVoteCount";
 import { VoteCards, VotesTable } from "../_components/VotesTable";
 import { VotingResult } from "../_components/VotingResult";
@@ -197,7 +200,15 @@ export default function ProposalDetailPage({
   );
 }
 
-function VotesList({ proposalVotes, pages, proposalId }): JSX.Element {
+function VotesList({
+  proposalVotes,
+  pages,
+  proposalId,
+}: {
+  proposalVotes: ApiPagedResponse<ProposalVotesResult>;
+  pages: CursorPage[];
+  proposalId: string;
+}): JSX.Element {
   return (
     <>
       {proposalVotes.length === 0 ? (
@@ -210,14 +221,15 @@ function VotesList({ proposalVotes, pages, proposalId }): JSX.Element {
           <div className="hidden md:block">
             <VotesTable votes={proposalVotes} />
           </div>
-          <div className="flex justify-end mt-8">
-            <CursorPagination
-              pages={pages}
-              path={`/on-chain-governance/${proposalId}`}
-            />
-          </div>
         </>
       )}
+
+      <div className="flex justify-end mt-8">
+        <CursorPagination
+          pages={pages}
+          path={`/on-chain-governance/${proposalId}`}
+        />
+      </div>
     </>
   );
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
- As titled, to provide consistent pagination behaviour at `/ocg/{id}` page
- Only reproducible when accessing the next page when number of votes for current active page = 10 (pagination size)

#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Sample Links & Screenshots:

<!--
(Optional) Provide a link to changes made using Netlify Preview deployment.
-->

Link:

<details>
<summary>Desktop Screenshot</summary>

<!-- Image has to be between break lines -->

</details>
<details>
<summary>Mobile Screenshot</summary>

<!-- Image has to be between break lines -->

</details>

#### Additional comments?:

#### Developer Checklist:

<!--
Merging into the main branch implies your code is ready for production.
Before requesting for code review, please ensure that the following tasks
are completed. Otherwise, keep the PR drafted.
-->

- [x] Read your code changes at least once
- [ ] Tested on multiple web browsers
- [x] Tested responsiveness (e.g, iPhone, iPad, Desktop)
- [ ] No console errors
- [ ] Unit tests\*
- [ ] Added e2e tests\*

<!--
* If applicable
-->
