### PR TITLE
fix(ui-ux): subdomain agnostic regex for discussion links

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,21 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
       - run: npx pretty-quick --staged --check --pattern "**/*.{js,jsx,ts,tsx}"
+
+  jest:
+    name: Unit Tests - Jest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+
+      - uses: pnpm/action-setup@c3b53f6a16e57305370b4ae5a540c2077a1d50dd # tag=v2.2.4
+        with:
+          version: 7.29.0
+
+      - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
+        with:
+          node-version: 16
+          cache: "pnpm"
+
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm test

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "cypress:open": "cypress open",
     "cypress:build": "CYPRESS=true next build",
     "cypress:run": "TZ=UTC cypress run --headless --browser chrome",
-    "playground:start": "docker-compose rm -fsv && docker-compose up"
+    "playground:start": "docker-compose rm -fsv && docker-compose up",
+    "test": "jest"
   },
   "dependencies": {
     "@babel/types": "^7.21.2",
@@ -32,6 +33,7 @@
     "date-fns": "^2.29.3",
     "dayjs": "^1.11.7",
     "install": "^0.13.0",
+    "jest": "^29.5.0",
     "lodash": "^4.17.21",
     "qrcode.react": "^3.1.0",
     "randomcolor": "^0.6.2",
@@ -62,5 +64,10 @@
     "node": "^18.0.0 || ^16.16.0",
     "pnpm": ">=7.29.0"
   },
-  "packageManager": "pnpm@7.29.0"
+  "packageManager": "pnpm@7.29.0",
+  "jest": {
+    "modulePathIgnorePatterns": [
+      "<rootDir>/cypress/"
+    ]
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,7 @@ specifiers:
   date-fns: ^2.29.3
   dayjs: ^1.11.7
   install: ^0.13.0
+  jest: ^29.5.0
   lodash: ^4.17.21
   node-forge: ^1.3.1
   postcss: ^8.4.21
@@ -58,6 +59,7 @@ dependencies:
   date-fns: 2.29.3
   dayjs: 1.11.7
   install: 0.13.0
+  jest: 29.5.0_@types+node@18.14.6
   lodash: 4.17.21
   qrcode.react: 3.1.0_react@18.2.0
   randomcolor: 0.6.2

--- a/src/utils/commons/LinkValidator.test.ts
+++ b/src/utils/commons/LinkValidator.test.ts
@@ -1,0 +1,54 @@
+import { isValidOCGGithubUrl, isValidOCGRedditUrl } from "./LinkValidator";
+
+const redditLinkWithSubdomain =
+  "https://www.reddit.com/r/defiblockchain/comments/11fj7i5/cfp_appreciation_of_the_work_done_by_k%C3%BCgi_in_the/";
+const redditLinkWithoutSubdomain =
+  "https://reddit.com/r/defiblockchain/comments/11gwg5h/euroc_on_defichain/";
+const gitHubLinkWithSubdomain =
+  "https://www.github.com/DeFiCh/dfips/issues/258";
+const gitHubLinkWithoutSubdomain = "https://github.com/DeFiCh/dfips/issues/256";
+const randomLink = "https://www.google.com";
+
+describe("Reddit validator", () => {
+  it("detects Reddit link with subdomain", () => {
+    expect.hasAssertions();
+
+    expect(isValidOCGRedditUrl(redditLinkWithSubdomain)).toEqual(true);
+  });
+
+  it("detects Reddit link without subdomain", () => {
+    expect.hasAssertions();
+
+    expect(isValidOCGRedditUrl(redditLinkWithoutSubdomain)).toEqual(true);
+  });
+
+  it("does not detect non-Reddit links", () => {
+    expect.hasAssertions();
+
+    expect(isValidOCGRedditUrl(gitHubLinkWithSubdomain)).toEqual(false);
+    expect(isValidOCGRedditUrl(gitHubLinkWithoutSubdomain)).toEqual(false);
+    expect(isValidOCGRedditUrl(randomLink)).toEqual(false);
+  });
+});
+
+describe("GitHub validator", () => {
+  it("detects GitHub link with subdomain", () => {
+    expect.hasAssertions();
+
+    expect(isValidOCGGithubUrl(gitHubLinkWithSubdomain)).toEqual(true);
+  });
+
+  it("detects GitHub link without subdomain", () => {
+    expect.hasAssertions();
+
+    expect(isValidOCGGithubUrl(gitHubLinkWithoutSubdomain)).toEqual(true);
+  });
+
+  it("does not detect non-GitHub links", () => {
+    expect.hasAssertions();
+
+    expect(isValidOCGGithubUrl(redditLinkWithSubdomain)).toEqual(false);
+    expect(isValidOCGGithubUrl(redditLinkWithoutSubdomain)).toEqual(false);
+    expect(isValidOCGGithubUrl(randomLink)).toEqual(false);
+  });
+});

--- a/src/utils/commons/LinkValidator.ts
+++ b/src/utils/commons/LinkValidator.ts
@@ -1,9 +1,11 @@
 export function isValidOCGGithubUrl(input: string) {
-  const regex = /https?:\/\/github\.com\/defich\/dfips\/issues\/\d+$/gim;
+  const regex =
+    /https?:\/\/(?:[^.]+\.)?github\.com\/defich\/dfips\/issues\/\d+$/gim;
   return regex.test(input);
 }
 
 export function isValidOCGRedditUrl(input: string) {
-  const regex = /https?:\/\/www\.reddit\.com\/r\/defiblockchain\/(.*)/gim;
+  const regex =
+    /https?:\/\/(?:[^.]+\.)?reddit\.com\/r\/defiblockchain\/(.*)/gim;
   return regex.test(input);
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
In prod, Reddit links appear as "Link" instead of "Reddit" when the `www` subdomain is not used. This bug is the opposite for GitHub links where it only works if there is no subdomain. 

#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes [WEB-312](https://birthday.atlassian.net/browse/WEB-312)

#### Sample Links & Screenshots:

<!--
(Optional) Provide a link to changes made using Netlify Preview deployment.
-->

Link:

<details>
<summary>Desktop Screenshot</summary>

<!-- Image has to be between break lines -->

</details>
<details>
<summary>Mobile Screenshot</summary>

<!-- Image has to be between break lines -->

</details>

#### Additional comments?:

#### Developer Checklist:

<!--
Merging into the main branch implies your code is ready for production.
Before requesting for code review, please ensure that the following tasks
are completed. Otherwise, keep the PR drafted.
-->

- [ ] Read your code changes at least once
- [ ] Tested on multiple web browsers
- [ ] Tested responsiveness (e.g, iPhone, iPad, Desktop)
- [ ] No console errors
- [ ] Unit tests\*
- [ ] Added e2e tests\*

<!--
* If applicable
-->


[WEB-312]: https://birthday.atlassian.net/browse/WEB-312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ